### PR TITLE
rename “tracer” as “reporter”

### DIFF
--- a/collector.proto
+++ b/collector.proto
@@ -56,8 +56,8 @@ message Span {
     repeated Log logs = 7;
 }
 
-message Tracer {
-    uint64 tracer_id = 1;
+message Reporter {
+    uint64 reporter_id = 1;
     repeated KeyValue tags = 4;
 }
 
@@ -82,7 +82,7 @@ message Auth {
 }
 
 message ReportRequest {
-    Tracer tracer = 1;
+    Reporter reporter = 1;
     Auth auth = 2;
     repeated Span spans = 3;
     uint32 timestamp_offset_micros = 5;


### PR DESCRIPTION
This will...
 * probably avoid some confusion between "trace_id" and "tracer_id" if not here than in other APIs
 * allow us to use the same nouns in other APIs (where the concept of "reporter" will make more sense than a "tracer")
 * IMO avoid some confusion by not splitting hairs about different parts of the "tracer implementation"

This shouldn't cause any wire compatibility problems, as we currently only use the tag numbers on the wire.