### PR TITLE
rename log keyvalues as fields

### DIFF
--- a/collector.proto
+++ b/collector.proto
@@ -17,7 +17,17 @@ message SpanContext {
     map<string, string> baggage = 3;
 }
 
-message KeyValue {
+message Tag {
+    string key = 1;
+    oneof value {
+        string string_value = 2;
+        int64 int_value = 3;
+        double double_value = 4;
+        bool bool_value = 5;
+    }
+}
+
+message LogField {
     string key = 1;
     oneof value {
         // Holds arbitrary string data; well-formed JSON strings should go in
@@ -34,7 +44,7 @@ message KeyValue {
 
 message Log {
     google.protobuf.Timestamp timestamp = 1;
-    repeated KeyValue keyvalues = 2;
+    repeated LogField fields = 2;
 }
 
 message Reference {
@@ -52,13 +62,13 @@ message Span {
     repeated Reference references = 3;
     google.protobuf.Timestamp start_timestamp = 4;
     uint64 duration_micros = 5;
-    repeated KeyValue tags = 6;
+    repeated Tag tags = 6;
     repeated Log logs = 7;
 }
 
 message Reporter {
     uint64 reporter_id = 1;
-    repeated KeyValue tags = 4;
+    repeated Tag tags = 4;
 }
 
 message MetricsSample {

--- a/collector.proto
+++ b/collector.proto
@@ -17,17 +17,8 @@ message SpanContext {
     map<string, string> baggage = 3;
 }
 
-message Tag {
-    string key = 1;
-    oneof value {
-        string string_value = 2;
-        int64 int_value = 3;
-        double double_value = 4;
-        bool bool_value = 5;
-    }
-}
-
-message LogField {
+// Represent both tags and log fields.
+message KeyValue {
     string key = 1;
     oneof value {
         // Holds arbitrary string data; well-formed JSON strings should go in
@@ -37,14 +28,14 @@ message LogField {
         double double_value = 4;
         bool bool_value = 5;
         // Must be a well-formed JSON value. Truncated JSON should go in
-        // string_value.
+        // string_value. Should not be used for tags.
         string json_value = 6;
     }
 }
 
 message Log {
     google.protobuf.Timestamp timestamp = 1;
-    repeated LogField fields = 2;
+    repeated KeyValue fields = 2;
 }
 
 message Reference {
@@ -62,13 +53,13 @@ message Span {
     repeated Reference references = 3;
     google.protobuf.Timestamp start_timestamp = 4;
     uint64 duration_micros = 5;
-    repeated Tag tags = 6;
+    repeated KeyValue tags = 6;
     repeated Log logs = 7;
 }
 
 message Reporter {
     uint64 reporter_id = 1;
-    repeated Tag tags = 4;
+    repeated KeyValue tags = 4;
 }
 
 message MetricsSample {


### PR DESCRIPTION
This is continuing in my goal of making the field and type names in our proto file be The Names We Want In Our APIs. *I'm not totally sure about this particular change and would love comments.* Two motivations:

1. (more important) Using the same struct for tags and log fields means that there are some well-typed cases that "shouldn't ever happen." In particular, when we added the "JSON value" option for a log field, we also added it for a tag. I'd rather not allow users to specify tags with JSON values using types as well as let users not have to worry about that case when reading back data.

2. (less important) Lots of the OT documentation refers to the parts of a log as "fields" and I'd like to be consistent with that.